### PR TITLE
Corrected silent arguments for install/uninstall

### DIFF
--- a/Source/tools/chocolateyinstall.ps1
+++ b/Source/tools/chocolateyinstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
 
-  silentArgs   = '/S'           # NSIS
+  silentArgs   = '-s'           # Squirrel
   validExitCodes= @(0) #please insert other valid exit codes here
 
   # optional, highly recommended

--- a/Source/tools/chocolateyuninstall.ps1
+++ b/Source/tools/chocolateyuninstall.ps1
@@ -8,7 +8,7 @@ $silentArgs = '/qn /norestart'
 # https://msdn.microsoft.com/en-us/library/aa376931(v=vs.85).aspx
 $validExitCodes = @(0, 3010, 1605, 1614, 1641)
 if ($installerType -ne 'MSI') {
-  $silentArgs = '/S'           # NSIS
+  $silentArgs = '--uninstall -s'  # Squirrel
   $validExitCodes = @(0)
 }
 


### PR DESCRIPTION
The installer and uninstaller that gitkraken uses is squirrel, while the silent arguments specified for this package uses the NSIS arguments, this is corrected with this PR (gitkraken doesn't launch either, when the correct arguments is used).

/CC @kevnord 